### PR TITLE
Improve handling of 404 error for commit message retrieval, fixes #52

### DIFF
--- a/src/main/kotlin/github/exceptions/InvalidCommitUrlException.kt
+++ b/src/main/kotlin/github/exceptions/InvalidCommitUrlException.kt
@@ -1,0 +1,4 @@
+package github.exceptions
+
+class InvalidCommitUrlException(url: String) :
+    Throwable("$url is not a valid commit url")


### PR DESCRIPTION
## Issue
From removed branches on forked repositories, we could not find them and the code did not show any indication, thus the result were incorrect.

Fixes #52.

## Proposed solution
A new exception is added to indicate the 404 in commits. Also, we fixed the issue of removed forked branches, by using the based repository.